### PR TITLE
Reformat Description Field

### DIFF
--- a/src/components/ViewEnvironments/Drawer/index.tsx
+++ b/src/components/ViewEnvironments/Drawer/index.tsx
@@ -24,7 +24,7 @@ type DrawerParams = {
 // the selected environment.
 function EnvironmentDrawer({ env, onClose }: DrawerParams) {
   return (
-    <Drawer anchor="right" open={true} onClose={onClose}>
+    <Drawer anchor="right" open={true} onClose={onClose} style={{ "zIndex": 2000 }}>
       <Box padding={'27px'}>
         <Box
           role='presentation'
@@ -51,7 +51,7 @@ function EnvironmentDrawer({ env, onClose }: DrawerParams) {
         <Divider />
         <Box style={{ "padding": "18px" }}>
           <Typography variant={'h4'} style={{ paddingBottom: '15px' }}>Description</Typography>
-          <Typography variant={'h3'} style={{ width: '400px' }}>{env.description}</Typography>
+          <Typography style={{ width: '400px', "whiteSpace": "pre-wrap", "overflowWrap": "anywhere" }}>{env.description}</Typography>
         </Box>
         <Box style={{ "padding": "18px", "width": "400px" }}>
           <Divider />

--- a/src/components/ViewEnvironments/Drawer/index.tsx
+++ b/src/components/ViewEnvironments/Drawer/index.tsx
@@ -24,7 +24,7 @@ type DrawerParams = {
 // the selected environment.
 function EnvironmentDrawer({ env, onClose }: DrawerParams) {
   return (
-    <Drawer anchor="right" open={true} onClose={onClose} style={{ "zIndex": 2000 }}>
+    <Drawer ModalProps={{ slotProps: { backdrop: { style: { cursor: "pointer" } } } }} anchor="right" open={true} onClose={onClose} style={{ "zIndex": 2000 }}>
       <Box padding={'27px'}>
         <Box
           role='presentation'

--- a/src/components/ViewEnvironments/EnvironmentTable/index.tsx
+++ b/src/components/ViewEnvironments/EnvironmentTable/index.tsx
@@ -35,7 +35,7 @@ function EnvironmentTable({ environments }: Environments) {
           <Box
             key={env.name}
             onClick={e => {
-              if ((e.target as HTMLElement).classList.contains("MuiBox-root")) {
+              if (!(e.target as HTMLElement).classList.contains("MuiBackdrop-root")) {
                 setDrawer(env)
               }
             }}

--- a/src/components/ViewEnvironments/EnvironmentTable/index.tsx
+++ b/src/components/ViewEnvironments/EnvironmentTable/index.tsx
@@ -44,7 +44,8 @@ function EnvironmentTable({ environments }: Environments) {
               backgroundColor: 'rgba(34, 51, 84, 0.02)',
               padding: '18px',
               margin: '0 0 18px 0',
-              position: 'relative'
+              position: 'relative',
+              cursor: "pointer"
             }}>
             <Tooltip title={buildMessages[i]} placement="top">
               {/* This is displaying some hardcoded colours to indicate the 

--- a/src/components/ViewEnvironments/EnvironmentTable/index.tsx
+++ b/src/components/ViewEnvironments/EnvironmentTable/index.tsx
@@ -34,6 +34,11 @@ function EnvironmentTable({ environments }: Environments) {
         return (
           <Box
             key={env.name}
+            onClick={e => {
+              if ((e.target as HTMLElement).classList.contains("MuiBox-root")) {
+                setDrawer(env)
+              }
+            }}
             sx={{
               borderRadius: '10px',
               backgroundColor: 'rgba(34, 51, 84, 0.02)',
@@ -62,9 +67,7 @@ function EnvironmentTable({ environments }: Environments) {
               alignItems: 'baseline'
             }}>
               <Typography
-                component={Link}
                 variant='h3'
-                onClick={() => setDrawer(env)}
                 sx={{ paddingLeft: '20.7px' }}>{env.name}
               </Typography>
 
@@ -80,7 +83,7 @@ function EnvironmentTable({ environments }: Environments) {
                 </Breadcrumbs>
               </Typography>
             </Box>
-            <Typography sx={{ padding: '9px 0 9px 20.7px' }}>{env.description}</Typography>
+            <Typography sx={{ padding: '9px 0 9px 20.7px' }}>{env.description.split("\n")[0]}</Typography>
             <Box sx={{ paddingLeft: '20.7px' }}>
               {env.packages.map((package_) => {
                 return (

--- a/src/style.css
+++ b/src/style.css
@@ -11,6 +11,7 @@
 	border: 0;
 	background-color: transparent;
 	color: #fff;
+	cursor: pointer;
 }
 
 .readme_copy button>svg {


### PR DESCRIPTION
Make the description field respect newlines in the drawer, and limit the description in the environment table to a single line.

Also open the drawer when any part of the environment entry is clicked, not just the title.