### PR TITLE
Virtualise package list to make package search faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.7",
         "react-router-dom": "^6.12.1",
-        "react-syntax-highlighter": "^15.5.0"
+        "react-syntax-highlighter": "^15.5.0",
+        "react-window": "^1.8.10"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -33,6 +34,7 @@
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "@types/react-syntax-highlighter": "^15.5.7",
+        "@types/react-window": "^1.8.8",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "@typescript-eslint/parser": "^5.59.7",
         "@vitejs/plugin-react-swc": "^3.0.0",
@@ -1606,6 +1608,15 @@
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
       "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4290,6 +4301,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5314,6 +5330,22 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
     "react-router-dom": "^6.12.1",
-    "react-syntax-highlighter": "^15.5.0"
+    "react-syntax-highlighter": "^15.5.0",
+    "react-window": "^1.8.10"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
@@ -43,6 +44,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@types/react-syntax-highlighter": "^15.5.7",
+    "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",
     "@vitejs/plugin-react-swc": "^3.0.0",

--- a/src/components/CreateEnvironment/MatchingEnv/index.tsx
+++ b/src/components/CreateEnvironment/MatchingEnv/index.tsx
@@ -39,7 +39,7 @@ function MatchingEnv(props: EnvRowParams) {
         <TableCell component="th" scope="row">
           {props.environment.path}/{props.environment.name}
         </TableCell>
-        <TableCell component="th" scope="row" sx={{ "white-space": "pre-line" }}>
+        <TableCell component="th" scope="row" sx={{ whiteSpace: "pre-line" }}>
           {props.environment.description.split("The following executables are added to your PATH")[0]}
         </TableCell>
       </TableRow>

--- a/src/components/CreateEnvironment/PackageSelect/Listbox/index.tsx
+++ b/src/components/CreateEnvironment/PackageSelect/Listbox/index.tsx
@@ -1,0 +1,92 @@
+import { ListSubheader, Typography, useMediaQuery, useTheme } from "@mui/material";
+import { HTMLAttributes, ReactElement, createContext, forwardRef, useContext, useEffect, useRef } from "react";
+import { VariableSizeList, ListChildComponentProps } from "react-window";
+
+// virtualised listbox, passed to <Autocomplete>.
+// substantially based on the example in the MUI documentation.
+export const Listbox = forwardRef<HTMLDivElement, HTMLAttributes<HTMLElement>>(function Listbox(props, ref) {
+  const { children, ...otherProps } = props;
+  const allChildren = (children as ReactElement[]).flatMap(child => [child, ...((child as { children? : ReactElement[] }).children || [])])
+
+  const theme = useTheme();
+  const smUp = useMediaQuery(theme.breakpoints.up('sm'), {
+    noSsr: true,
+  });
+  const itemCount = allChildren.length;
+  const itemSize = smUp ? 36 : 48;
+
+  const getChildSize = (child: React.ReactElement) => {
+    if (child.hasOwnProperty("group")) {
+      return 48;
+    }
+
+    return itemSize;
+  };
+
+  const getHeight = () => {
+    if (itemCount > 8) {
+      return 8 * itemSize;
+    }
+    return allChildren.map(getChildSize).reduce((a, b) => a + b, 0);
+  };
+
+  const gridRef = useResetCache(itemCount);
+
+  return <div ref={ref}>
+    <OuterElementContext.Provider value={otherProps}>
+      <VariableSizeList
+        itemData={allChildren}
+        height={getHeight() + 2 * LISTBOX_PADDING}
+        width="100%"
+        ref={gridRef}
+        outerElementType={OuterElementType}
+        innerElementType="ul"
+        itemSize={(index) => getChildSize(allChildren[index])}
+        overscanCount={5}
+        itemCount={itemCount}
+      >
+        {renderRow}
+      </VariableSizeList>
+    </OuterElementContext.Provider>
+  </div>;
+});
+
+const LISTBOX_PADDING = 8;
+
+function renderRow(props: ListChildComponentProps) {
+  const { data, index, style } = props;
+  const dataSet = data[index];
+  const inlineStyle = {
+    ...style,
+    top: (style.top as number) + LISTBOX_PADDING,
+  };
+  if (dataSet.hasOwnProperty("group")) {
+    return (
+      <ListSubheader key={dataSet.key} component="div" style={inlineStyle}>
+        {dataSet.group}
+      </ListSubheader>
+    );
+  }
+  return (
+    <Typography component="li" {...dataSet.props} noWrap style={inlineStyle}>
+      {dataSet.option}
+    </Typography>
+  );
+}
+
+function useResetCache(data: any) {
+  const ref = useRef<VariableSizeList>(null);
+  useEffect(() => {
+    if (ref.current != null) {
+      ref.current.resetAfterIndex(0, true);
+    }
+  }, [data]);
+  return ref;
+}
+
+const OuterElementContext = createContext({});
+
+const OuterElementType = forwardRef<HTMLDivElement>((props, ref) => {
+  const outerProps = useContext(OuterElementContext);
+  return <div ref={ref} {...props} {...outerProps} />;
+});

--- a/src/components/CreateEnvironment/PackageSelect/index.tsx
+++ b/src/components/CreateEnvironment/PackageSelect/index.tsx
@@ -1,7 +1,8 @@
 import { Autocomplete, Box, TextField } from "@mui/material";
 import DropdownChip from "../../PackageChip";
 import { Package } from "../../../queries";
-import { useMemo } from "react";
+import { ReactNode, useMemo } from "react";
+import { Listbox } from "./Listbox";
 
 type PackageSelectParams = {
   packages: Map<string, string[]>;
@@ -35,7 +36,9 @@ export default function PackageSelect(props: PackageSelectParams) {
       <Autocomplete
         multiple
         disableCloseOnSelect
+        disableListWrap
         options={[...props.packages.keys()]}
+        ListboxComponent={Listbox}
         renderTags={renderTags}
         renderInput={(params) => {
           return (
@@ -46,6 +49,10 @@ export default function PackageSelect(props: PackageSelectParams) {
             />
           );
         }}
+        renderOption={(props, option, state) => (
+          // this gets passed to Listbox's renderRow, but we have to lie about the type...
+          { props, option, state } as unknown as ReactNode
+        )}
         value={selectedPackageNames}
         onChange={(_, value) => {
           const prevVersions = new Map<string, string | null>();

--- a/src/components/ViewEnvironments/EnvironmentTable/index.tsx
+++ b/src/components/ViewEnvironments/EnvironmentTable/index.tsx
@@ -1,6 +1,6 @@
 import type { Environment, Environments, States } from "../../../queries";
 import { Box, Chip, LinearProgress, Tooltip, Typography } from "@mui/material";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import EnvironmentDrawer, { breadcrumbs } from "../Drawer";
 
 type State = {
@@ -28,7 +28,7 @@ function EnvironmentTable({ environments }: Environments) {
 
   return (
     <>
-      {environments.map(env => <>
+      {environments.map(env => <Fragment key={env.id}>
         <Box
           onClick={() => setDrawer(env)}
           sx={{
@@ -99,7 +99,7 @@ function EnvironmentTable({ environments }: Environments) {
             onClose={() => setDrawer(null)}
           />
         }
-      </>)}
+      </Fragment>)}
     </>
   );
 }


### PR DESCRIPTION
Rendering thousands of DOM nodes is slow, it turns out. If we only create DOM nodes for elements that are actually within the viewable part of the list of available packages, everything becomes much more responsive – the package list now opens and closes instantly, and searching is much faster too.

Also fixes a couple of warnings emitted in the console.