### PR TITLE
Use unique value for environment key

### DIFF
--- a/src/components/ViewEnvironments/EnvironmentTable/index.tsx
+++ b/src/components/ViewEnvironments/EnvironmentTable/index.tsx
@@ -28,7 +28,7 @@ function EnvironmentTable({ environments }: Environments) {
 
   return (
     <>
-      {environments.map(env => <Fragment key={env.id}>
+      {environments.map(env => <Fragment key={`${env.path}/${env.name}`}>
         <Box
           onClick={() => setDrawer(env)}
           sx={{

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -8,7 +8,6 @@ export type States = "queued" | "ready" | "failed";
 
 export type Environment = {
   description: string;
-  id: string;
   name: string;
   packages: Package[];
   readme: string;
@@ -26,7 +25,6 @@ export const ALL_ENVIRONMENTS = gql`
   query {
     environments {
       description
-      id
       name
       path
       packages {


### PR DESCRIPTION
confusingly, "id" was not unique! (it's the hash/oid of the _tree_ that corresponds to the environment – so if two identical environments exist, e.g. because both are stuck in the building state, they'll have the same `id`. Note that trees do not themselves have names, so the environments having different names/paths didn't contribute.)

This fixes some very weird issues where searching for environments appeared to create duplicate copies of some environments.

Also: nothing actually uses `id`! so we just remove all references to it.