### PR TITLE
Improve messaging for builds submitted when builder unavailable

### DIFF
--- a/src/components/CreateEnvironment/PackageSettings/index.tsx
+++ b/src/components/CreateEnvironment/PackageSettings/index.tsx
@@ -18,7 +18,6 @@ type PackageSettingsParams = {
   setSelectedPackages: (packages: Package[]) => void;
   runEnvironmentBuild: () => void;
   envBuildInFlight: boolean;
-  envBuildSuccessful: boolean;
 };
 
 // PackageSettings is the card responsible for enabling the user to select the


### PR DESCRIPTION
After https://github.com/wtsi-hgi/softpack-core/pull/48, builds will be queued even on a failure response from the builder. Reflect this in the web UI.