### PR TITLE
Disable (very slow) cache.

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,16 @@ const client = new ApolloClient({
     window.location.hostname +
     `:${import.meta.env.VITE_CORE_PORT ?? 8000}/graphql`,
   cache: new InMemoryCache(),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'all',
+    },
+    query: {
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'all',
+    },
+  }
 });
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(


### PR DESCRIPTION
Apollo Client cache does not seem to like hundreds of objects in it, which is what causes the incredibly long startup times.

Have disabled the cache to significantly improve startup times.